### PR TITLE
BLD: base/Dockerfile: easy_install -> https:get-pip.py, -m pip

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -27,10 +27,13 @@ RUN apt-get -y install libfreetype6 g++ sqlite libevent-dev libffi-dev \
     libfreetype6-dev libtiff5-dev libjpeg8-dev zlib1g-dev liblcms2-dev \
     libwebp-dev
 
-RUN easy_install3 pip
-RUN easy_install-2.7 pip
-RUN pip3 install -U virtualenv
-RUN pip2 install -U virtualenv
+RUN curl https://bootstrap.pypa.io/get-pip.py
+RUN python2.7 ./get-pip.py
+RUN python3 ./get-pip.py
+#RUN python3.4+ -m ensurepip --upgrade
+
+RUN python2.7 -m pip install -U virtualenv
+RUN python3 -m pip install -U virtualenv
 
 # UID and GID from readthedocs/user
 RUN groupadd --gid 205 docs


### PR DESCRIPTION
easy_install is not safe w/ Python < 2.7.9-10. AFAIU, the current recommendation is to prefer pip.


Python

* https://hg.python.org/cpython/raw-file/2.7/Misc/NEWS
* https://docs.python.org/3/whatsnew/changelog.html
* Ubuntu 14.04: Python v2.7.5:
  http://packages.ubuntu.com/trusty/python

easy_install -> ssl // pip -> backports.ssl_match_hostname

* "Enabling certificate verification by default for stdlib http clients"
  http://legacy.python.org/dev/peps/pep-0476/
  * https://pypi.python.org/pypi/backports.ssl_match_hostname (for < 3.4)
    * [ ] ``python -m pip install backports.ssl_match_hostname`` does not change the default SSLContext (PEP 476 changes the default SSLContext to validate SSL hostnames by default)
  * https://docs.python.org/2/library/ssl.html#ssl.match_hostname (2.7.9+)
 
.

- [ ] DOC: (remove/uncomment) `python3 -m ensurepip --upgrade [--user?]` w/ 3.4+
- [ ] BLD: Makefile: Add `curl -- get-pip.py`
- [ ] TST,PLS: Test these changes to the Docker image