### PR TITLE
Add auxlib for conda

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -29,9 +29,8 @@ RUN apt-get -y install libfreetype6 g++ sqlite libevent-dev libffi-dev \
 
 RUN easy_install3 pip
 RUN easy_install-2.7 pip
-RUN pip3 install -U virtualenv
-RUN pip2 install -U virtualenv
-RUN pip2 install -U auxlib
+RUN pip3 install -U virtualenv auxlib
+RUN pip2 install -U virtualenv auxlib
 RUN pip2 install -U conda
 
 # UID and GID from readthedocs/user

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -31,6 +31,7 @@ RUN easy_install3 pip
 RUN easy_install-2.7 pip
 RUN pip3 install -U virtualenv
 RUN pip2 install -U virtualenv
+RUN pip2 install -U auxlib
 RUN pip2 install -U conda
 
 # UID and GID from readthedocs/user


### PR DESCRIPTION
Greetings, not sure if you take pull requests, but I had to add this `auxlib` install in order to build the docker images on a relatively fresh Ubuntu 14.04 machine. It seems `conda` requires it: https://github.com/conda/conda/issues/2182. Thanks!