### PR TITLE
Fix conda permissions in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN useradd -m --uid 1005 --gid 205 docs
 USER docs
 
 # Install miniconda as docs user
+WORKDIR /home/docs
 RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.2.11-Linux-x86_64.sh
 RUN bash Miniconda2-4.2.11-Linux-x86_64.sh -b -p /home/docs/miniconda2/
 RUN mkdir /home/docs/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,14 +33,15 @@ RUN easy_install3 pip
 RUN easy_install pip
 RUN pip3 install -U virtualenv auxlib
 RUN pip2 install -U virtualenv auxlib
-RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.2.11-Linux-x86_64.sh
-RUN bash Miniconda2-4.2.11-Linux-x86_64.sh -b -p /usr/local/miniconda/
-RUN ln -s /usr/local/miniconda/bin/conda /usr/local/bin/conda
 
 # UID and GID from readthedocs/user
 RUN groupadd --gid 205 docs
 RUN useradd -m --uid 1005 --gid 205 docs
 
 USER docs
+
+RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.2.11-Linux-x86_64.sh
+RUN bash Miniconda2-4.2.11-Linux-x86_64.sh -b -p /usr/local/miniconda/
+RUN ln -s /usr/local/miniconda/bin/conda /usr/local/bin/conda
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,10 @@ RUN useradd -m --uid 1005 --gid 205 docs
 
 USER docs
 
+# Install miniconda as docs user
 RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.2.11-Linux-x86_64.sh
-RUN bash Miniconda2-4.2.11-Linux-x86_64.sh -b -p /usr/local/miniconda/
-RUN ln -s /usr/local/miniconda/bin/conda /usr/local/bin/conda
+RUN bash Miniconda2-4.2.11-Linux-x86_64.sh -b -p /home/docs/miniconda2/
+RUN mkdir /home/docs/bin
+RUN ln -s /home/docs/miniconda2/bin/conda /home/docs/bin/conda
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,8 @@ USER docs
 
 # Install miniconda as docs user
 WORKDIR /home/docs
-RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.2.11-Linux-x86_64.sh
-RUN bash Miniconda2-4.2.11-Linux-x86_64.sh -b -p /home/docs/miniconda2/
-RUN mkdir /home/docs/bin
-RUN ln -s /home/docs/miniconda2/bin/conda /home/docs/bin/conda
+RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.11-Linux-x86_64.sh
+RUN bash Miniconda2-4.3.11-Linux-x86_64.sh -b -p /home/docs/miniconda2/
+env PATH $PATH:/home/docs/miniconda2/bin
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Install miniconda2 as `docs` user instead of as `root`

This potentially fixes #24 

There are more reference about this at https://github.com/rtfd/readthedocs.org/issues/2651#issuecomment-284888039