### PR TITLE
Update conda path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ USER docs
 # Install miniconda as docs user
 WORKDIR /home/docs
 RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.11-Linux-x86_64.sh
-RUN bash Miniconda2-4.3.11-Linux-x86_64.sh -b -p /home/docs/miniconda2/
-env PATH $PATH:/home/docs/miniconda2/bin
+RUN bash Miniconda2-4.3.11-Linux-x86_64.sh -b -p /home/docs/.conda/
+env PATH $PATH:/home/docs/.conda/bin
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
I don't know if we need to change the conda version, but this installs into a
path that copies that pyenv installation pattern from our latest image