### PR TITLE
Add conda-forge channel to the 2.x build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Read the Docs - Environment base
 FROM ubuntu:16.04
 MAINTAINER Read the Docs <support@readthedocs.com>
-LABEL version="2.0.1"
+LABEL version="2.0.2"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV APPDIR /app
@@ -48,6 +48,7 @@ env PATH $PATH:/home/docs/.conda/bin
 
 # Add conda-forge channel with the highest channel priority
 RUN conda config --add channels conda-forge
+# Don't have conda try and upgrade itself, so we can pin a version
 RUN conda config --set auto_update_conda false
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,7 @@ env PATH $PATH:/home/docs/.conda/bin
 
 # Add conda-forge channel with the highest channel priority
 RUN conda config --add channels conda-forge
+RUN conda config --set auto_update_conda false
+
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,7 @@ RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.11-Linux-x86_64.s
 RUN bash Miniconda2-4.3.11-Linux-x86_64.sh -b -p /home/docs/.conda/
 env PATH $PATH:/home/docs/.conda/bin
 
+# Add conda-forge channel with the highest channel priority
+RUN conda config --add channels conda-forge
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
Closes https://github.com/rtfd/readthedocs.org/issues/2713

If this is something we want, I will make another PR to do the same in the `latest` build image.

We need some testing for this, also.