### PR TITLE
Add support for sphinx-js via JSDoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN apt-get -y install python-pip && pip install -U virtualenv auxlib
 RUN groupadd --gid 205 docs
 RUN useradd -m --uid 1005 --gid 205 docs
 
+# Install jsdoc
+RUN apt-get -y install nodejs nodejs-legacy npm && npm install --global jsdoc
+
 USER docs
 WORKDIR /home/docs
 


### PR DESCRIPTION
This lets JavaScript and mixed Python-JS projects build their docs on RTD, by providing the `jsdoc` command which sphinx-js needs. (Note that `nodejs-legacy` is necessary because the executables that `npm` creates expect `node` to invoke node.js.)

I've tested this with my project [Lorikeet](https://gitlab.com/abre/lorikeet), which uses sphinx-js 1.3.x, as well as with Mozilla's [Fathom](http://mozilla.github.io/fathom) (the project [mentioned in conjunction with sphinx-js recently on hacks.mozilla.org](https://hacks.mozilla.org/2017/07/introducing-sphinx-js-a-better-way-to-document-large-javascript-projects/)) using sphinx-js 2.0.1.

Closes #21.