### PR TITLE
Add basic dependency checks for out of date miniconda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.cache/
+Pipfile.lock
+__pycache__
+.ropeproject/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "3.6"
+before_install:
+  - pip install pipenv
+install:
+  - pipenv install --system
+script: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ LABEL version="latest"
 ENV DEBIAN_FRONTEND noninteractive
 ENV APPDIR /app
 ENV LANG C.UTF-8
+ENV CONDA_VERSION 4.3.27.1
 
 # System dependencies
 RUN apt-get -y update
@@ -51,8 +52,8 @@ USER docs
 WORKDIR /home/docs
 
 # Install Conda
-RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-4.3.27.1-Linux-x86_64.sh
-RUN bash Miniconda2-4.3.27.1-Linux-x86_64.sh -b -p /home/docs/.conda/
+RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh
+RUN bash Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh -b -p /home/docs/.conda/
 ENV PATH $PATH:/home/docs/.conda/bin
 
 # Install pyenv

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[dev-packages]
+
+[packages]
+
+"dockerfile-parse" = "*"
+requests = "*"
+pytest = "*"

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,28 @@
+"""
+Check dependencies of our images, fail builds on out of date bits
+"""
+
+import requests
+from dockerfile_parse import DockerfileParser
+
+
+def get_dockerfile():
+    return DockerfileParser()
+
+def test_miniconda():
+    """Test miniconda latest version matches our version"""
+    base_url = 'https://repo.continuum.io/miniconda'
+    dockerfile = get_dockerfile()
+    conda_version = dockerfile.envs.get('CONDA_VERSION')
+    latest = requests.head(
+        '{base}/Miniconda2-latest-Linux-x86_64.sh'.format(
+            base=base_url
+        )
+    )
+    current = requests.head(
+        '{base}/Miniconda2-{version}-Linux-x86_64.sh'.format(
+            base=base_url,
+            version=conda_version,
+        )
+    )
+    assert current.headers['etag'] == latest.headers['etag']


### PR DESCRIPTION
This checks the md5 hash of latest vs our current miniconda version. With use
of travis cron job, we can get notice of failures here, indicating we should
upgrade. I'm sure we could automate with some tool creation of an issue on this
failure too -- later though.

This can also be expanded later to include some of the other dependencies we're
adding, maybe security checks against ubuntu repositories, python, etc