### PR TITLE
Add github-linguist to the setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get -y install nodejs nodejs-legacy npm && npm install --global jsdoc
 
 # Install linguist for programming language detection
 RUN apt-get -y install ruby-github-linguist
+RUN ln -s /usr/bin/github-linguist /usr/local/bin/linguist
 
 USER docs
 WORKDIR /home/docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN useradd -m --uid 1005 --gid 205 docs
 # Install jsdoc
 RUN apt-get -y install nodejs nodejs-legacy npm && npm install --global jsdoc
 
+# Install linguist for programming language detection
+RUN apt-get -y install ruby-github-linguist
+
 USER docs
 WORKDIR /home/docs
 


### PR DESCRIPTION
This adds [github-linguist](https://github.com/github/linguist) which is used to get a programming language breakdown of directory. This can be used on a git checkout to tell the primary language of a project.

A separate PR is coming for readthedocs.org to add this to our build process.