### PR TITLE
Bump to Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Read the Docs - Environment base
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Read the Docs <support@readthedocs.com>
 LABEL version="latest"
 
@@ -8,11 +8,10 @@ ENV APPDIR /app
 ENV LANG C.UTF-8
 
 # Versions, and expose labels for exernal usage
-ENV PYTHON_VERSION_27 2.7.13
-ENV PYTHON_VERSION_33 3.3.6
-ENV PYTHON_VERSION_34 3.4.7
-ENV PYTHON_VERSION_35 3.5.4
-ENV PYTHON_VERSION_36 3.6.2
+ENV PYTHON_VERSION_27 2.7.14
+ENV PYTHON_VERSION_33 3.3.7
+ENV PYTHON_VERSION_35 3.5.5
+ENV PYTHON_VERSION_36 3.6.4
 ENV CONDA_VERSION 4.4.10
 LABEL python.version_27=$PYTHON_VERSION_27
 LABEL python.version_33=$PYTHON_VERSION_33
@@ -59,7 +58,7 @@ RUN groupadd --gid 205 docs
 RUN useradd -m --uid 1005 --gid 205 docs
 
 # Install jsdoc
-RUN apt-get -y install nodejs nodejs-legacy npm && npm install --global jsdoc
+RUN apt-get -y install nodejs npm && npm install --global jsdoc
 
 USER docs
 WORKDIR /home/docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,10 @@ ENV LANG C.UTF-8
 
 # Versions, and expose labels for exernal usage
 ENV PYTHON_VERSION_27 2.7.14
-ENV PYTHON_VERSION_33 3.3.7
 ENV PYTHON_VERSION_35 3.5.5
 ENV PYTHON_VERSION_36 3.6.4
 ENV CONDA_VERSION 4.4.10
 LABEL python.version_27=$PYTHON_VERSION_27
-LABEL python.version_33=$PYTHON_VERSION_33
-LABEL python.version_34=$PYTHON_VERSION_34
 LABEL python.version_35=$PYTHON_VERSION_35
 LABEL python.version_36=$PYTHON_VERSION_36
 LABEL conda.version=$CONDA_VERSION
@@ -77,14 +74,10 @@ ENV PATH /home/docs/.pyenv/shims:$PATH:/home/docs/.pyenv/bin
 RUN pyenv install $PYTHON_VERSION_27 && \
     pyenv install $PYTHON_VERSION_36 && \
     pyenv install $PYTHON_VERSION_35 && \
-    pyenv install $PYTHON_VERSION_34 && \
-    pyenv install $PYTHON_VERSION_33 && \
     pyenv global \
         $PYTHON_VERSION_27 \
         $PYTHON_VERSION_36 \
-        $PYTHON_VERSION_35 \
-        $PYTHON_VERSION_34 \
-        $PYTHON_VERSION_33
+        $PYTHON_VERSION_35
 
 WORKDIR /tmp
 
@@ -102,17 +95,6 @@ RUN pyenv local $PYTHON_VERSION_35 && \
     pyenv exec pip install -U pip && \
     pyenv exec pip install --only-binary numpy,scipy numpy scipy && \
     pyenv exec pip install pandas matplotlib virtualenv
-
-RUN pyenv local $PYTHON_VERSION_34 && \
-    pyenv exec pip install -U pip && \
-    pyenv exec pip install --only-binary numpy,scipy numpy scipy && \
-    pyenv exec pip install pandas matplotlib virtualenv
-
-RUN pyenv local $PYTHON_VERSION_33 && \
-    pyenv exec pip install -U pip && \
-    pyenv exec pip install --only-binary numpy,scipy numpy scipy && \
-    pyenv exec pip install "pandas<0.18" "matplotlib<1.5" virtualenv && \
-    pyenv local --unset
 
 WORKDIR /
 


### PR DESCRIPTION
Use of labels here it to help with features in the future.

Some notes here:

* As raised in #56, Python 3.4 doesn't build on 18.04 because of the modern
  glibc. 3.3 still builds, and 3.5 and 3.6 are patched. But 3.4 is in security
  fix only mode now. I'm fine dropping 3.4
* I don't know why `nodejs-legacy` is required, but it's not in 18.04
  anyways, so that was also removed
* This will require a change to https://github.com/rtfd/readthedocs-build/blob/master/readthedocs_build/config/config.py