### PR TITLE
Call pip properly on pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ before_install:
   - pip install pipenv
 install:
   - pipenv install
-script: pipenv run pytest
+script:
+  - pipenv run pytest
+  - docker build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ install:
 script:
   - pipenv run pytest
   - docker build .
+
+branches:
+  only:
+    - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,7 +177,8 @@ RUN pyenv local $PYTHON_VERSION_36 && \
     pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv
 
 RUN pyenv local $PYPY_VERSION_35 && \
-    pyenv exec pip install --no-cache-dir -U pip && \
+    pyenv exec python -m ensurepip && \
+    pyenv exec pip3 install --no-cache-dir -U pip && \
     pyenv exec pip install --no-cache-dir virtualenv
 
 WORKDIR /


### PR DESCRIPTION
This PR fixes the Docker build that was broken because of pypy installation introduced at #93