### PR TITLE
Upgrade setuptools on Python from system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,22 +171,26 @@ WORKDIR /tmp
 
 RUN pyenv local $PYTHON_VERSION_27 && \
     pyenv exec pip install --no-cache-dir -U pip && \
+    pyenv exec pip install --no-cache-dir -U setuptools && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
     pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv
 
 RUN pyenv local $PYTHON_VERSION_37 && \
     pyenv exec pip install --no-cache-dir -U pip && \
+    pyenv exec pip install --no-cache-dir -U setuptools && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
     pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv
 
 RUN pyenv local $PYTHON_VERSION_36 && \
     pyenv exec pip install --no-cache-dir -U pip && \
+    pyenv exec pip install --no-cache-dir -U setuptools && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
     pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv
 
 RUN pyenv local $PYPY_VERSION_35 && \
     pyenv exec python -m ensurepip && \
     pyenv exec pip3 install --no-cache-dir -U pip && \
+    pyenv exec pip install --no-cache-dir -U setuptools && \
     pyenv exec pip install --no-cache-dir virtualenv
 
 WORKDIR /


### PR DESCRIPTION
We were upgrading `pip` but it's also a good idea to upgrade `setuptools` as well.

Related to https://github.com/rtfd/readthedocs.org/issues/5572