### PR TITLE
Re-add Python 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,13 @@ ENV LANG C.UTF-8
 
 # Versions, and expose labels for external usage
 ENV PYTHON_VERSION_27 2.7.16
+ENV PYTHON_VERSION_35 3.5.7
 ENV PYTHON_VERSION_36 3.6.8
 ENV PYTHON_VERSION_37 3.7.3
 ENV PYPY_VERSION_35 pypy3.5-7.0.0
 ENV CONDA_VERSION 4.6.14
 LABEL python.version_27=$PYTHON_VERSION_27
+LABEL python.version_35=$PYTHON_VERSION_35
 LABEL python.version_36=$PYTHON_VERSION_36
 LABEL python.version_37=$PYTHON_VERSION_37
 LABEL pypy.version_35=$PYPY_VERSION_35
@@ -159,12 +161,14 @@ ENV PATH /home/docs/.pyenv/shims:$PATH:/home/docs/.pyenv/bin
 # Install supported Python versions
 RUN pyenv install $PYTHON_VERSION_27 && \
     pyenv install $PYTHON_VERSION_37 && \
+    pyenv install $PYTHON_VERSION_35 && \
     pyenv install $PYTHON_VERSION_36 && \
     pyenv install $PYPY_VERSION_35 && \
     pyenv global \
         $PYTHON_VERSION_27 \
         $PYTHON_VERSION_37 \
         $PYTHON_VERSION_36 \
+        $PYTHON_VERSION_35 \
         $PYPY_VERSION_35
 
 WORKDIR /tmp
@@ -182,6 +186,12 @@ RUN pyenv local $PYTHON_VERSION_37 && \
     pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv
 
 RUN pyenv local $PYTHON_VERSION_36 && \
+    pyenv exec pip install --no-cache-dir -U pip && \
+    pyenv exec pip install --no-cache-dir -U setuptools && \
+    pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
+    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv
+
+RUN pyenv local $PYTHON_VERSION_35 && \
     pyenv exec pip install --no-cache-dir -U pip && \
     pyenv exec pip install --no-cache-dir -U setuptools && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \


### PR DESCRIPTION
Python 3.5 was removed at https://github.com/rtfd/readthedocs-docker-images/pull/84/ and we didn't have a good reason to do it.

Then, when releasing the new Docker 5.0 image we realize that we will be breaking some projects that are pinning 3.5 in their config file: https://github.com/rtfd/readthedocs.org/pull/5657

So, we decided to re-add it to be able to deploy this image without breaking people's projects.